### PR TITLE
Fix log time

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Better Learn",
   "description": "Companion extension for Up Learn.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",


### PR DESCRIPTION
Fix #5 

$`\log_{10}(time)`$ should probably periodically make API calls until the total time needed is actually reached. Maybe also communicate to the popup if a request is successful and prevent spamming logs.

It would also make sense to source different videos to use when logging from the same subsection, since it only works with complete videos.